### PR TITLE
feat: finish game level up

### DIFF
--- a/supabase/functions/common/_shared/gameSessionService.ts
+++ b/supabase/functions/common/_shared/gameSessionService.ts
@@ -1,127 +1,163 @@
 import { and, eq, lt, desc } from "npm:drizzle-orm@^0.31.4/expressions";
 import { db } from "../db.ts";
-import { gameSessionsTable, levelsTable } from "../schema.ts";
+import { gameSessionsTable, levelsTable, playersTable } from "../schema.ts";
 import { getCurrentDifficulty } from "./playerService.ts";
-import { checkSameDay, getNewAchivements } from "./achievementsService.ts";
+import { checkSameDay, getNewAchivements as getNewAchievements } from "./achievementsService.ts";
 import { gameSessionInterface } from "./interfaces.ts";
 import { getLevelByScore } from "./levelService.ts";
 import { playersBoostersTable } from "../schema.ts";
 import { takeUniqueOrThrow } from "./takeUniqueOrThrow.ts";
 
-export async function startGame(playerId : number){
-    // TODO random boss and booster
+export async function startGame(playerId: number) {
+  // TODO random boss and booster
 
-    await cancelGame(playerId) // cancel currently active game(s)
-    const currentDifficultyId = await getCurrentDifficulty(playerId)
+  await cancelGame(playerId); // cancel currently active game(s)
+  const currentDifficultyId = await getCurrentDifficulty(playerId);
 
-    await db.insert(gameSessionsTable).values({
-        player_id : playerId,
-        difficulty_id : currentDifficultyId,
-        boss_id: 1,
-        booster_drop_id: 1,
-        score : 0,
-        lap : 1,
-        status: "ACTIVE"
-    })
+  await db.insert(gameSessionsTable).values({
+    player_id: playerId,
+    difficulty_id: currentDifficultyId,
+    boss_id: 1,
+    booster_drop_id: 1,
+    score: 0,
+    lap: 1,
+    status: "ACTIVE",
+  });
 }
 
-export async function cancelGame(playerId : number) {
-    await db.update(gameSessionsTable).set({
-        status : "CANCEL",
-        ended_at : new Date()
-    }).where(and(
-        eq(gameSessionsTable.status,"ACTIVE"),
-        eq(gameSessionsTable.player_id,playerId)
-    ))
+export async function cancelGame(playerId: number) {
+  await db
+    .update(gameSessionsTable)
+    .set({
+      status: "CANCEL",
+      ended_at: new Date(),
+    })
+    .where(
+      and(
+        eq(gameSessionsTable.status, "ACTIVE"),
+        eq(gameSessionsTable.player_id, playerId)
+      )
+    );
 }
 
-export async function updateGame(playerId : number, score : number, lap : number) {
-    const updatedGame = await db.update(gameSessionsTable).set({
-        lap : lap,
-        score : score,
-        updated_at: new Date()
-    }).where(and(
-        eq(gameSessionsTable.player_id,playerId),
-        eq(gameSessionsTable.status,"ACTIVE")
-    )).returning()
+export async function updateGame(playerId: number, score: number, lap: number) {
+  const updatedGame = await db
+    .update(gameSessionsTable)
+    .set({
+      lap: lap,
+      score: score,
+      updated_at: new Date(),
+    })
+    .where(
+      and(
+        eq(gameSessionsTable.player_id, playerId),
+        eq(gameSessionsTable.status, "ACTIVE")
+      )
+    )
+    .returning();
 
-    if(updatedGame.length === 0) throw new Error("No Currently Active Game to Update")
+  if (updatedGame.length === 0)
+    throw new Error("No Currently Active Game to Update");
 }
 
-export async function finishGame(playerId : number, score : number, lap : number, isBoosterReceived : boolean) {
+export async function finishGame(
+  playerId: number,
+  score: number,
+  playerTotalScore: number,
+  lap: number,
+  isBoosterReceived: boolean
+) {
+  if (lap !== 10) throw new Error("Incorrect Lap");
 
-    if (lap !== 10) throw new Error("Incorrect Lap")
-    
-    let boosterDropId : number = 0
-    const now = new Date()
-    await db.transaction(async (tx) => {
-        const game = await tx.update(gameSessionsTable).set({
-            lap : lap,
-            score : score,
-            updated_at: now,
-            ended_at: now,
-            status : "END"
-        }).where(and(
-            eq(gameSessionsTable.player_id,playerId),
-            eq(gameSessionsTable.status,"ACTIVE")
-        )).returning().then(takeUniqueOrThrow)
-        console.log(game)
-        if(isBoosterReceived) {
-            await tx.insert(playersBoostersTable).values({
-                player_id : playerId,
-                booster_id : game.booster_drop_id,
-                status : "ACTIVE"
-            })
-        }
-        boosterDropId = game.booster_drop_id
-    })
+  let boosterDropId: number = 0;
+  const now = new Date();
+  await db.transaction(async (tx) => {
+    const game = await tx
+      .update(gameSessionsTable)
+      .set({
+        lap: lap,
+        score: score,
+        updated_at: now,
+        ended_at: now,
+        status: "END",
+      })
+      .where(
+        and(
+          eq(gameSessionsTable.player_id, playerId),
+          eq(gameSessionsTable.status, "ACTIVE")
+        )
+      )
+      .returning()
+      .then(takeUniqueOrThrow);
 
-    const newAchievements = await getNewAchivements(playerId)
-    const totalGames = getTotalGames(playerId)
-    const gamesPlayedToday = getGamesPlayedToday(playerId)
+    console.log(game);
 
-    // get level
-    const allGameSessions = await db.select().from(gameSessionsTable).where(eq(gameSessionsTable.player_id,playerId))
-
-    let totalScore = 0
-    allGameSessions.forEach((gameSession) => {
-        totalScore = totalScore + (gameSession.score === null ? 0 : gameSession.score)
-    })
-
-    const level = await db.select().from(levelsTable).where(lt(levelsTable.score_required,totalScore)).orderBy(desc(levelsTable.score_required))
-    const newLevel = level[0]
-    const oldLevel = await getLevelByScore(totalScore - score)
-    const isLevelUp : boolean = newLevel === oldLevel
-
-    return {
-        new_achievements : newAchievements,
-        total_games : totalGames,
-        games_played_today : gamesPlayedToday,
-        level_up : isLevelUp,
-        level : newLevel,
-        booster : isBoosterReceived ? boosterDropId : null
+    if (isBoosterReceived) {
+      await tx.insert(playersBoostersTable).values({
+        player_id: playerId,
+        booster_id: game.booster_drop_id,
+        status: "ACTIVE",
+      });
     }
+    boosterDropId = game.booster_drop_id;
+  });
+
+  const newAchievements = await getNewAchievements(playerId);
+  const totalGames = getTotalGames(playerId);
+  const gamesPlayedToday = getGamesPlayedToday(playerId);
+
+  const level = await db
+    .select()
+    .from(levelsTable)
+    .where(lt(levelsTable.score_required, playerTotalScore + score))
+    .orderBy(desc(levelsTable.score_required));
+  const newLevel = level[0];
+  const oldLevel = await getLevelByScore(playerTotalScore);
+  const isLevelUp: boolean = newLevel.level !== oldLevel.level;
+
+  await db.transaction(async (tx) => {
+    await tx
+      .update(playersTable)
+      .set({ total_score: playerTotalScore + score })
+      .where(eq(playersTable.id, playerId))
+      .returning()
+      .then(takeUniqueOrThrow);
+  })
+
+  return {
+    new_achievements: newAchievements,
+    total_games: totalGames,
+    games_played_today: gamesPlayedToday,
+    level_up: isLevelUp,
+    level: newLevel,
+    booster: isBoosterReceived ? boosterDropId : null,
+  };
 }
 
-export async function getTotalGames(playerId : number){
-    const allGames = await db.select().from(gameSessionsTable).where(eq(gameSessionsTable.player_id,playerId))
-    return allGames.length
+export async function getTotalGames(playerId: number) {
+  const allGames = await db
+    .select()
+    .from(gameSessionsTable)
+    .where(eq(gameSessionsTable.player_id, playerId));
+  return allGames.length;
 }
 
-export async function getGamesPlayedToday(playerId : number) {
-    const allGames = await db.select().from(gameSessionsTable).where(eq(gameSessionsTable.player_id,playerId)).orderBy(gameSessionsTable.started_at)
-    const now = new Date()
-    const gamesPlayedToday : gameSessionInterface[] = []
+export async function getGamesPlayedToday(playerId: number) {
+  const allGames = await db
+    .select()
+    .from(gameSessionsTable)
+    .where(eq(gameSessionsTable.player_id, playerId))
+    .orderBy(gameSessionsTable.started_at);
+  const now = new Date();
+  const gamesPlayedToday: gameSessionInterface[] = [];
 
-    allGames.forEach((gameSession) => {
+  allGames.forEach((gameSession) => {
+    const isSameDay = checkSameDay(now, gameSession.started_at);
 
-        const isSameDay = checkSameDay(now,gameSession.started_at)
-        
-        if(isSameDay) {
-            gamesPlayedToday.push(gameSession)
-        }
-        else return
-    })
+    if (isSameDay) {
+      gamesPlayedToday.push(gameSession);
+    } else return;
+  });
 
-    return gamesPlayedToday
+  return gamesPlayedToday;
 }

--- a/supabase/functions/common/schema.ts
+++ b/supabase/functions/common/schema.ts
@@ -34,7 +34,7 @@ export const playersTable = pgTable('players_table', {
   birth_year: integer('birth_year'),
   airflow: integer('airflow'),
   last_played_at: timestamp('last_played_at'),
-  
+  total_score: integer('total_score').notNull().default(0)
 })
 
 export const vasTable = pgTable('vas_table', {
@@ -48,7 +48,18 @@ export const vasTable = pgTable('vas_table', {
 export const levelsTable = pgTable('levels_table', {
   id: serial('id').primaryKey(),
   level: integer('level').notNull().unique(),
-  score_required: integer('score_required').notNull()
+  score_required: integer('score_required').notNull(),
+  boss_id: integer('boss_id')
+  .references(() => bossesTable.id, { onDelete: 'no action' }),
+  booster_id_1:  integer('booster_id_1')
+  .references(() => boostersTable.id, { onDelete: 'no action' }),
+  booster_id_2:  integer('booster_id_2')
+  .references(() => boostersTable.id, { onDelete: 'no action' }),
+  booster_id_3:  integer('booster_id_3')
+  .references(() => boostersTable.id, { onDelete: 'no action' }),
+  booster_amount_1: integer('booster_amount_1').default(0),
+  booster_amount_2: integer('booster_amount_2').default(0),
+  booster_amount_3: integer('booster_amount_3').default(0),
 })
 
 export const gameSessionsTable = pgTable('game_sessions_table', {

--- a/supabase/functions/common/seed.ts
+++ b/supabase/functions/common/seed.ts
@@ -1,11 +1,11 @@
-import { 
-     bossesTable,
-     boostersTable, 
-     charactersTable, 
-     difficultiesTable,
-     achievementsTable,
-     levelsTable
-} from "./schema.ts"
+import {
+  bossesTable,
+  boostersTable,
+  charactersTable,
+  difficultiesTable,
+  achievementsTable,
+  levelsTable,
+} from "./schema.ts";
 import postgres from "npm:postgres";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { config } from "https://deno.land/x/dotenv@v3.2.0/mod.ts";
@@ -23,311 +23,340 @@ const db = drizzle(client);
 
 // run by $ deno run .\supabase\functions\common\seed.ts
 const seed = async () => {
+  // seeding Bosses Table
+  console.log("Seeding Bosses...");
+  try {
+    await db.insert(bossesTable).values([
+      {
+        id: 1,
+        name: "เอเลี่ยนซ่า",
+      },
+      {
+        id: 2,
+        name: "สไลม์คิง",
+      },
+      {
+        id: 3,
+        name: "ก็อตซ่า",
+      },
+      {
+        id: 4,
+        name: "ไอซ์โกเลม",
+      },
+      {
+        id: 5,
+        name: "ไก่ทอด",
+      },
+    ]);
+    console.log("Seed Bosses Done");
+  } catch (error) {
+    console.log("BossesTable: ", error);
+  }
 
-     // seeding Levels Table
-     console.log("Seeding Levels")
-     try {
-          await db.insert(levelsTable).values([
-               {
-                    id: 1,
-                    level: 1,
-                    score_required: 0,
-               },
-               {
-                    id: 2,
-                    level: 2,
-                    score_required: 85000,
-               },
-               {
-                    id: 3,
-                    level: 3,
-                    score_required: 850000,
-               },
-               {
-                    id: 4,
-                    level: 4,
-                    score_required: 2125000,
-               },
-               {
-                    id: 5,
-                    level: 5,
-                    score_required: 3825000,
-               },
-               {
-                    id: 6,
-                    level: 6,
-                    score_required: 5190000,
-               },
-               {
-                    id: 7,
-                    level: 7,
-                    score_required: 10200000,
-               },
-               {
-                    id: 8,
-                    level: 8,
-                    score_required: 15300000,
-               },
-               {
-                    id: 9,
-                    level: 9,
-                    score_required: 21250000,
-               },
-               {
-                    id: 10,
-                    level: 10,
-                    score_required: 28050000,
-               },
-          ])
-          console.log("Seed Levels Done")
-     } catch (error) {
-          console.log("LevelsTable : ", error)
-     }
-    
-     // seeding Bosses Table
-     console.log("Seeding Bosses...")
-     try {
-          await db.insert(bossesTable).values([
-               {
-                    id: 1,
-                    name: "เอเลี่ยนซ่า"
-               },
-               {
-                    id: 2,
-                    name: "สไลม์คิง"
-               },
-               {
-                    id: 3,
-                    name: "แมว"
-               },
-               {
-                    id: 4,
-                    name: "คางคก"
-               },
-               {
-                    id: 5,
-                    name: "ไก่ทอด"
-               }
-          ])
-          console.log("Seed Bosses Done")
-     } catch (error) {
-          console.log("BossesTable: ", error);
-     }
-     
-     // seeding boosters Table
-     console.log("Seeding Boosters...")
-     try {
-          await db.insert(boostersTable).values([{
-                    id: 1,
-                    name: "booster1",
-                    type: "NORMAL"
-               },
-               {
-                    id: 2,
-                    name: "booster2",
-                    type: "NORMAL"
-               },
-               {
-                    id: 3,
-                    name: "booster3",
-                    type: "NORMAL"
-               },
-               {
-                    id: 4,
-                    name: "booster4",
-                    type: "NORMAL"
-               },
-               {
-                    id: 5,
-                    name: "booster5",
-                    type: "NORMAL"
-               },
-               {
-                    id: 6,
-                    name: "booster_rare1",
-                    type: "RARE"
-               },
-               {
-                    id: 7,
-                    name: "booster_rare2",
-                    type: "RARE"
-               }
-          ])
-          console.log("Seed Boosters Done")
-     } catch (error) {
-          console.log("BoostersTable: ", error);
-     }
+  // seeding boosters Table
+  console.log("Seeding Boosters...");
+  try {
+    await db.insert(boostersTable).values([
+      {
+        id: 1,
+        name: "booster1",
+        type: "NORMAL",
+      },
+      {
+        id: 2,
+        name: "booster2",
+        type: "NORMAL",
+      },
+      {
+        id: 3,
+        name: "booster3",
+        type: "NORMAL",
+      },
+      {
+        id: 4,
+        name: "booster4",
+        type: "NORMAL",
+      },
+      {
+        id: 5,
+        name: "booster5",
+        type: "NORMAL",
+      },
+      {
+        id: 6,
+        name: "booster_rare1",
+        type: "RARE",
+      },
+      {
+        id: 7,
+        name: "booster_rare2",
+        type: "RARE",
+      },
+    ]);
+    console.log("Seed Boosters Done");
+  } catch (error) {
+    console.log("BoostersTable: ", error);
+  }
 
-     // seeding characters table
-     console.log("Seeding Characters...")
-     try {
-          await db.insert(charactersTable).values([
-               {
-                    id: 1,
-                    name: "นักผจญภัย",
-                    detail: "ลุยแบบสุดขีด เต็มพลัง",
-                    achievement_number_required: 0
-               },
-               {
-                    id: 2,
-                    name: "นักเวทย์",
-                    detail: "เวทย์มนต์ไม่ใช่ของตั้งโชว์นะ",
-                    achievement_number_required: 4
-               },
-               {
-                    id: 3,
-                    name: "จอมโจร",
-                    detail: "สมบัติของเธอ ขอรับไปละนะ",
-                    achievement_number_required: 8
-               },
-               {
-                    id: 4,
-                    name: "มือปราบ",
-                    detail: "ด้วยอำนาจเจ้าหน้าที่ตำรวจสากล ขอใช้กำลังเช้าจับกุม",
-                    achievement_number_required: 12
-               }
-          ])
-          console.log("Seed Characters Done")
-     } catch (error) {
-          console.log("CharactersTable: ", error);
-     }
+  
+  // seeding Levels Table
+  console.log("Seeding Levels");
+  try {
+    await db.insert(levelsTable).values([
+      {
+        id: 1,
+        level: 1,
+        score_required: 0,
+      },
+      {
+        id: 2,
+        level: 2,
+        score_required: 85000,
+        boss_id: 2,
+      },
+      {
+        id: 3,
+        level: 3,
+        score_required: 850000,
+        booster_id_1: 4,
+        booster_id_2: 5,
+        booster_id_3: 6,
+        booster_amount_1: 5,
+        booster_amount_2: 5,
+        booster_amount_3: 5,
+      },
+      {
+        id: 4,
+        level: 4,
+        score_required: 2125000,
+        boss_id: 3
+      },
+      {
+        id: 5,
+        level: 5,
+        score_required: 3825000,
+        booster_id_1: 4,
+        booster_id_2: 5,
+        booster_id_3: 7,
+        booster_amount_1: 5,
+        booster_amount_2: 5,
+        booster_amount_3: 5,
+      },
+      {
+        id: 6,
+        level: 6,
+        score_required: 5190000,
+        boss_id: 4
+      },
+      {
+        id: 7,
+        level: 7,
+        score_required: 10200000,
+        booster_id_1: 4,
+        booster_id_2: 5,
+        booster_id_3: 6,
+        booster_amount_1: 5,
+        booster_amount_2: 5,
+        booster_amount_3: 5,
+      },
+      {
+        id: 8,
+        level: 8,
+        score_required: 15300000,
+      },
+      {
+        id: 9,
+        level: 9,
+        score_required: 21250000,
+        booster_id_1: 4,
+        booster_id_2: 5,
+        booster_id_3: 7,
+        booster_amount_1: 5,
+        booster_amount_2: 5,
+        booster_amount_3: 5,
+      },
+      {
+        id: 10,
+        level: 10,
+        score_required: 28050000,
+      },
+    ]);
+    console.log("Seed Levels Done");
+  } catch (error) {
+    console.log("LevelsTable : ", error);
+  }
 
-     // seeding difficulties table
-     console.log("Seeding Difficulties...")
-     try {
-          await db.insert(difficultiesTable).values([
-               {
-                    id: 1,
-                    name: "ง่าย",
-                    inhale_second: 0.5
-               },
-               {
-                    id: 2,
-                    name: "ปานกลาง",
-                    inhale_second: 1
-               },
-               {
-                    id: 3,
-                    name: "ยาก",
-                    inhale_second: 2
-               }
-          ])
-          console.log("Seed Difficulties Done")
-     } catch (error) {
-          console.log("DifficultiesTable: ", error);
-     }
 
-     // seeding Achievements Table
-     console.log("Seeding Achievements...")
-     try {
-          await db.insert(achievementsTable).values([
-               {
-                    id: 1,
-                    name: "3hearts",
-                    games_played_in_a_day: 3
-               },
-               {
-                    id: 2,
-                    name: "3days",
-                    games_played_consecutive_days: 3
-               },
-               {
-                    id: 3,
-                    name: "5days",
-                    games_played_consecutive_days: 5
-               },
-               {
-                    id: 4,
-                    name: "7days",
-                    games_played_consecutive_days: 7
-               },
-               {
-                    id: 5,
-                    name: "500k",
-                    accumulative_score: 5e5
-               },
-               {
-                    id: 6,
-                    name: "3M",
-                    accumulative_score: 3e6
-               },
-               {
-                    id: 7,
-                    name: "8M",
-                    accumulative_score: 8e6
-               },
-               {
-                    id: 8,
-                    name: "20M",
-                    accumulative_score: 20e6
-               },
-               {
-                    id: 9,
-                    name: "10 games",
-                    games_played: 10
-               },
-               {
-                    id: 10,
-                    name: "100 games",
-                    games_played: 100
-               },
-               {
-                    id: 11,
-                    name: "200 games",
-                    games_played: 200
-               },
-               {
-                    id: 12,
-                    name: "10 boosters",
-                    boosters_number: 10,
-                    booster_action: "USE",
-                    booster_type: "NORMAL",
-                    booster_unique: "NONUNIQUE"
-               },
-               {
-                    id: 13,
-                    name: "5boosterrares",
-                    boosters_number: 5,
-                    booster_action: "USE",
-                    booster_type: "RARE",
-                    booster_unique: "NONUNIQUE"
-               },
-               {
-                    id: 14,
-                    name: "7boosters", 
-                    boosters_number: 7,
-                    booster_action: "GAIN",
-                    booster_unique: "UNIQUE"
-               },
-               {
-                    id: 15,
-                    name: "20gamesb4",
-                    boss_encounter: 20,
-                    boss_id: 4
-               },
-               {
-                    id: 16,
-                    name: "30gamesb5",
-                    boss_encounter: 30,
-                    boss_id: 5
-               },
-               {
-                    id: 17,
-                    name: "4mc",
-                    characters_unlocked: 4
-               },
-          ])
-          console.log("Seed Achievements Done")
-     } catch (error) {
-          console.log("AchievementsTable : ", error)
-     }
-}
+  // seeding characters table
+  console.log("Seeding Characters...");
+  try {
+    await db.insert(charactersTable).values([
+      {
+        id: 1,
+        name: "นักผจญภัย",
+        detail: "ลุยแบบสุดขีด เต็มพลัง",
+        achievement_number_required: 0,
+      },
+      {
+        id: 2,
+        name: "นักเวทย์",
+        detail: "เวทย์มนต์ไม่ใช่ของตั้งโชว์นะ",
+        achievement_number_required: 4,
+      },
+      {
+        id: 3,
+        name: "จอมโจร",
+        detail: "สมบัติของเธอ ขอรับไปละนะ",
+        achievement_number_required: 8,
+      },
+      {
+        id: 4,
+        name: "มือปราบ",
+        detail: "ด้วยอำนาจเจ้าหน้าที่ตำรวจสากล ขอใช้กำลังเช้าจับกุม",
+        achievement_number_required: 12,
+      },
+    ]);
+    console.log("Seed Characters Done");
+  } catch (error) {
+    console.log("CharactersTable: ", error);
+  }
 
-console.log('Seed Start')
+  // seeding difficulties table
+  console.log("Seeding Difficulties...");
+  try {
+    await db.insert(difficultiesTable).values([
+      {
+        id: 1,
+        name: "ง่าย",
+        inhale_second: 0.5,
+      },
+      {
+        id: 2,
+        name: "ปานกลาง",
+        inhale_second: 1,
+      },
+      {
+        id: 3,
+        name: "ยาก",
+        inhale_second: 2,
+      },
+    ]);
+    console.log("Seed Difficulties Done");
+  } catch (error) {
+    console.log("DifficultiesTable: ", error);
+  }
+
+  // seeding Achievements Table
+  console.log("Seeding Achievements...");
+  try {
+    await db.insert(achievementsTable).values([
+      {
+        id: 1,
+        name: "3hearts",
+        games_played_in_a_day: 3,
+      },
+      {
+        id: 2,
+        name: "3days",
+        games_played_consecutive_days: 3,
+      },
+      {
+        id: 3,
+        name: "5days",
+        games_played_consecutive_days: 5,
+      },
+      {
+        id: 4,
+        name: "7days",
+        games_played_consecutive_days: 7,
+      },
+      {
+        id: 5,
+        name: "500k",
+        accumulative_score: 5e5,
+      },
+      {
+        id: 6,
+        name: "3M",
+        accumulative_score: 3e6,
+      },
+      {
+        id: 7,
+        name: "8M",
+        accumulative_score: 8e6,
+      },
+      {
+        id: 8,
+        name: "20M",
+        accumulative_score: 20e6,
+      },
+      {
+        id: 9,
+        name: "10 games",
+        games_played: 10,
+      },
+      {
+        id: 10,
+        name: "100 games",
+        games_played: 100,
+      },
+      {
+        id: 11,
+        name: "200 games",
+        games_played: 200,
+      },
+      {
+        id: 12,
+        name: "10 boosters",
+        boosters_number: 10,
+        booster_action: "USE",
+        booster_type: "NORMAL",
+        booster_unique: "NONUNIQUE",
+      },
+      {
+        id: 13,
+        name: "5boosterrares",
+        boosters_number: 5,
+        booster_action: "USE",
+        booster_type: "RARE",
+        booster_unique: "NONUNIQUE",
+      },
+      {
+        id: 14,
+        name: "7boosters",
+        boosters_number: 7,
+        booster_action: "GAIN",
+        booster_unique: "UNIQUE",
+      },
+      {
+        id: 15,
+        name: "20gamesb4",
+        boss_encounter: 20,
+        boss_id: 4,
+      },
+      {
+        id: 16,
+        name: "30gamesb5",
+        boss_encounter: 30,
+        boss_id: 5,
+      },
+      {
+        id: 17,
+        name: "4mc",
+        characters_unlocked: 4,
+      },
+    ]);
+    console.log("Seed Achievements Done");
+  } catch (error) {
+    console.log("AchievementsTable : ", error);
+  }
+};
+
+console.log("Seed Start");
 seed()
-.catch((e) => {
-     console.error(e)
-})
-.finally(() => {
-     console.log('Seed Done')
-})
+  .catch((e) => {
+    console.error(e);
+  })
+  .finally(() => {
+    console.log("Seed Done");
+  });

--- a/supabase/functions/finish-game/index.ts
+++ b/supabase/functions/finish-game/index.ts
@@ -24,8 +24,9 @@ Deno.serve(async (req) => {
     const firebaseId = getFirebaseId(authHeader)
     const player = await db.select().from(playersTable).where(eq(playersTable.firebase_id, firebaseId)).then(takeUniqueOrThrow)
     const playerId = player.id
+    const playerTotalScore = player.total_score
 
-    const result = await finishGame(playerId,score,lap,is_booster_received)
+    const result = await finishGame(playerId, score, playerTotalScore, lap, is_booster_received)
   
     const response = {message : "Ok", 
       response : result
@@ -33,16 +34,16 @@ Deno.serve(async (req) => {
 
     return new Response(
       JSON.stringify(response),
-      { headers: { ...corsHeaders, "Content-Type": "application/json" } },
+      {status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } },
     )
   }
   catch(error){
     const response = {
-      message : error.message,
+      error : error.message,
     }
     return new Response(
       JSON.stringify(response),
-      { headers: { ...corsHeaders, "Content-Type": "application/json" } },
+      {status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } },
     )
   }
 })

--- a/supabase/migrations/0006_exotic_shooting_star.sql
+++ b/supabase/migrations/0006_exotic_shooting_star.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "players_table" ADD COLUMN "total_score" integer;

--- a/supabase/migrations/0007_optimal_ink.sql
+++ b/supabase/migrations/0007_optimal_ink.sql
@@ -1,0 +1,32 @@
+ALTER TABLE "players_table" ALTER COLUMN "total_score" SET DEFAULT 0;--> statement-breakpoint
+ALTER TABLE "players_table" ALTER COLUMN "total_score" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "levels_table" ADD COLUMN "boss_id" integer;--> statement-breakpoint
+ALTER TABLE "levels_table" ADD COLUMN "booster_id_1" integer;--> statement-breakpoint
+ALTER TABLE "levels_table" ADD COLUMN "booster_id_2" integer;--> statement-breakpoint
+ALTER TABLE "levels_table" ADD COLUMN "booster_id_3" integer;--> statement-breakpoint
+ALTER TABLE "levels_table" ADD COLUMN "booster_amount_1" integer DEFAULT 0;--> statement-breakpoint
+ALTER TABLE "levels_table" ADD COLUMN "booster_amount_2" integer DEFAULT 0;--> statement-breakpoint
+ALTER TABLE "levels_table" ADD COLUMN "booster_amount_3" integer DEFAULT 0;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "levels_table" ADD CONSTRAINT "levels_table_boss_id_bosses_table_id_fk" FOREIGN KEY ("boss_id") REFERENCES "public"."bosses_table"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "levels_table" ADD CONSTRAINT "levels_table_booster_id_1_boosters_table_id_fk" FOREIGN KEY ("booster_id_1") REFERENCES "public"."boosters_table"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "levels_table" ADD CONSTRAINT "levels_table_booster_id_2_boosters_table_id_fk" FOREIGN KEY ("booster_id_2") REFERENCES "public"."boosters_table"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "levels_table" ADD CONSTRAINT "levels_table_booster_id_3_boosters_table_id_fk" FOREIGN KEY ("booster_id_3") REFERENCES "public"."boosters_table"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/supabase/migrations/meta/0006_snapshot.json
+++ b/supabase/migrations/meta/0006_snapshot.json
@@ -1,0 +1,867 @@
+{
+  "id": "ba0156c7-1e75-4594-b4ce-46f8ca62a55f",
+  "prevId": "5157b55b-84de-4954-a065-4e004ca7d24c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.achievements_table": {
+      "name": "achievements_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "games_played_in_a_day": {
+          "name": "games_played_in_a_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "games_played_consecutive_days": {
+          "name": "games_played_consecutive_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accumulative_score": {
+          "name": "accumulative_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "games_played": {
+          "name": "games_played",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boosters_number": {
+          "name": "boosters_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "booster_type": {
+          "name": "booster_type",
+          "type": "booster_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "booster_action": {
+          "name": "booster_action",
+          "type": "booster_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "booster_unique": {
+          "name": "booster_unique",
+          "type": "booster_unique",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boss_id": {
+          "name": "boss_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boss_encounter": {
+          "name": "boss_encounter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "characters_unlocked": {
+          "name": "characters_unlocked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "achievements_table_boss_id_bosses_table_id_fk": {
+          "name": "achievements_table_boss_id_bosses_table_id_fk",
+          "tableFrom": "achievements_table",
+          "tableTo": "bosses_table",
+          "columnsFrom": [
+            "boss_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "achievements_table_name_unique": {
+          "name": "achievements_table_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.boosters_table": {
+      "name": "boosters_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "booster_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "boosters_table_name_unique": {
+          "name": "boosters_table_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.bosses_table": {
+      "name": "bosses_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bosses_table_name_unique": {
+          "name": "bosses_table_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.characters_table": {
+      "name": "characters_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achievement_number_required": {
+          "name": "achievement_number_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "characters_table_name_unique": {
+          "name": "characters_table_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.difficulties_table": {
+      "name": "difficulties_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inhale_second": {
+          "name": "inhale_second",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "difficulties_table_name_unique": {
+          "name": "difficulties_table_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.game_sessions_table": {
+      "name": "game_sessions_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty_id": {
+          "name": "difficulty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boss_id": {
+          "name": "boss_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "booster_drop_id": {
+          "name": "booster_drop_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "booster_drop_duration": {
+          "name": "booster_drop_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lap": {
+          "name": "lap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "game_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_sessions_table_player_id_players_table_id_fk": {
+          "name": "game_sessions_table_player_id_players_table_id_fk",
+          "tableFrom": "game_sessions_table",
+          "tableTo": "players_table",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_sessions_table_difficulty_id_difficulties_table_id_fk": {
+          "name": "game_sessions_table_difficulty_id_difficulties_table_id_fk",
+          "tableFrom": "game_sessions_table",
+          "tableTo": "difficulties_table",
+          "columnsFrom": [
+            "difficulty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_sessions_table_boss_id_bosses_table_id_fk": {
+          "name": "game_sessions_table_boss_id_bosses_table_id_fk",
+          "tableFrom": "game_sessions_table",
+          "tableTo": "bosses_table",
+          "columnsFrom": [
+            "boss_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_sessions_table_booster_drop_id_boosters_table_id_fk": {
+          "name": "game_sessions_table_booster_drop_id_boosters_table_id_fk",
+          "tableFrom": "game_sessions_table",
+          "tableTo": "boosters_table",
+          "columnsFrom": [
+            "booster_drop_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.levels_table": {
+      "name": "levels_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score_required": {
+          "name": "score_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "levels_table_level_unique": {
+          "name": "levels_table_level_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "level"
+          ]
+        }
+      }
+    },
+    "public.players_achievements_table": {
+      "name": "players_achievements_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achievement_id": {
+          "name": "achievement_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "players_achievements_table_player_id_players_table_id_fk": {
+          "name": "players_achievements_table_player_id_players_table_id_fk",
+          "tableFrom": "players_achievements_table",
+          "tableTo": "players_table",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "players_achievements_table_achievement_id_achievements_table_id_fk": {
+          "name": "players_achievements_table_achievement_id_achievements_table_id_fk",
+          "tableFrom": "players_achievements_table",
+          "tableTo": "achievements_table",
+          "columnsFrom": [
+            "achievement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.players_boosters_table": {
+      "name": "players_boosters_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "booster_id": {
+          "name": "booster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "player_booster_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "players_boosters_table_player_id_players_table_id_fk": {
+          "name": "players_boosters_table_player_id_players_table_id_fk",
+          "tableFrom": "players_boosters_table",
+          "tableTo": "players_table",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "players_boosters_table_booster_id_boosters_table_id_fk": {
+          "name": "players_boosters_table_booster_id_boosters_table_id_fk",
+          "tableFrom": "players_boosters_table",
+          "tableTo": "boosters_table",
+          "columnsFrom": [
+            "booster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.players_characters_table": {
+      "name": "players_characters_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "players_characters_table_player_id_players_table_id_fk": {
+          "name": "players_characters_table_player_id_players_table_id_fk",
+          "tableFrom": "players_characters_table",
+          "tableTo": "players_table",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "players_characters_table_character_id_characters_table_id_fk": {
+          "name": "players_characters_table_character_id_characters_table_id_fk",
+          "tableFrom": "players_characters_table",
+          "tableTo": "characters_table",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.players_table": {
+      "name": "players_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "firebase_id": {
+          "name": "firebase_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty_id": {
+          "name": "difficulty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_character_id": {
+          "name": "selected_character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_year": {
+          "name": "birth_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "airflow": {
+          "name": "airflow",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_played_at": {
+          "name": "last_played_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "players_table_difficulty_id_difficulties_table_id_fk": {
+          "name": "players_table_difficulty_id_difficulties_table_id_fk",
+          "tableFrom": "players_table",
+          "tableTo": "difficulties_table",
+          "columnsFrom": [
+            "difficulty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "players_table_selected_character_id_characters_table_id_fk": {
+          "name": "players_table_selected_character_id_characters_table_id_fk",
+          "tableFrom": "players_table",
+          "tableTo": "characters_table",
+          "columnsFrom": [
+            "selected_character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "players_table_firebase_id_unique": {
+          "name": "players_table_firebase_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "firebase_id"
+          ]
+        },
+        "players_table_phone_number_unique": {
+          "name": "players_table_phone_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone_number"
+          ]
+        }
+      }
+    },
+    "public.vas_table": {
+      "name": "vas_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vas_score": {
+          "name": "vas_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vas_table_player_id_players_table_id_fk": {
+          "name": "vas_table_player_id_players_table_id_fk",
+          "tableFrom": "vas_table",
+          "tableTo": "players_table",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.booster_action": {
+      "name": "booster_action",
+      "schema": "public",
+      "values": [
+        "USE",
+        "GAIN"
+      ]
+    },
+    "public.booster_type": {
+      "name": "booster_type",
+      "schema": "public",
+      "values": [
+        "NORMAL",
+        "RARE"
+      ]
+    },
+    "public.booster_unique": {
+      "name": "booster_unique",
+      "schema": "public",
+      "values": [
+        "UNIQUE",
+        "NONUNIQUE"
+      ]
+    },
+    "public.game_session_status": {
+      "name": "game_session_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "CANCEL",
+        "END"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "M",
+        "F"
+      ]
+    },
+    "public.player_booster_status": {
+      "name": "player_booster_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "USED"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/supabase/migrations/meta/0007_snapshot.json
+++ b/supabase/migrations/meta/0007_snapshot.json
@@ -1,0 +1,966 @@
+{
+  "id": "c2ed9078-ae97-4454-a747-3da7a43a13a8",
+  "prevId": "ba0156c7-1e75-4594-b4ce-46f8ca62a55f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.achievements_table": {
+      "name": "achievements_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "games_played_in_a_day": {
+          "name": "games_played_in_a_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "games_played_consecutive_days": {
+          "name": "games_played_consecutive_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accumulative_score": {
+          "name": "accumulative_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "games_played": {
+          "name": "games_played",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boosters_number": {
+          "name": "boosters_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "booster_type": {
+          "name": "booster_type",
+          "type": "booster_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "booster_action": {
+          "name": "booster_action",
+          "type": "booster_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "booster_unique": {
+          "name": "booster_unique",
+          "type": "booster_unique",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boss_id": {
+          "name": "boss_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boss_encounter": {
+          "name": "boss_encounter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "characters_unlocked": {
+          "name": "characters_unlocked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "achievements_table_boss_id_bosses_table_id_fk": {
+          "name": "achievements_table_boss_id_bosses_table_id_fk",
+          "tableFrom": "achievements_table",
+          "tableTo": "bosses_table",
+          "columnsFrom": [
+            "boss_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "achievements_table_name_unique": {
+          "name": "achievements_table_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.boosters_table": {
+      "name": "boosters_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "booster_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "boosters_table_name_unique": {
+          "name": "boosters_table_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.bosses_table": {
+      "name": "bosses_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bosses_table_name_unique": {
+          "name": "bosses_table_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.characters_table": {
+      "name": "characters_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achievement_number_required": {
+          "name": "achievement_number_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "characters_table_name_unique": {
+          "name": "characters_table_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.difficulties_table": {
+      "name": "difficulties_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inhale_second": {
+          "name": "inhale_second",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "difficulties_table_name_unique": {
+          "name": "difficulties_table_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.game_sessions_table": {
+      "name": "game_sessions_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty_id": {
+          "name": "difficulty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boss_id": {
+          "name": "boss_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "booster_drop_id": {
+          "name": "booster_drop_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "booster_drop_duration": {
+          "name": "booster_drop_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lap": {
+          "name": "lap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "game_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_sessions_table_player_id_players_table_id_fk": {
+          "name": "game_sessions_table_player_id_players_table_id_fk",
+          "tableFrom": "game_sessions_table",
+          "tableTo": "players_table",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_sessions_table_difficulty_id_difficulties_table_id_fk": {
+          "name": "game_sessions_table_difficulty_id_difficulties_table_id_fk",
+          "tableFrom": "game_sessions_table",
+          "tableTo": "difficulties_table",
+          "columnsFrom": [
+            "difficulty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_sessions_table_boss_id_bosses_table_id_fk": {
+          "name": "game_sessions_table_boss_id_bosses_table_id_fk",
+          "tableFrom": "game_sessions_table",
+          "tableTo": "bosses_table",
+          "columnsFrom": [
+            "boss_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_sessions_table_booster_drop_id_boosters_table_id_fk": {
+          "name": "game_sessions_table_booster_drop_id_boosters_table_id_fk",
+          "tableFrom": "game_sessions_table",
+          "tableTo": "boosters_table",
+          "columnsFrom": [
+            "booster_drop_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.levels_table": {
+      "name": "levels_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score_required": {
+          "name": "score_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boss_id": {
+          "name": "boss_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "booster_id_1": {
+          "name": "booster_id_1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "booster_id_2": {
+          "name": "booster_id_2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "booster_id_3": {
+          "name": "booster_id_3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "booster_amount_1": {
+          "name": "booster_amount_1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "booster_amount_2": {
+          "name": "booster_amount_2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "booster_amount_3": {
+          "name": "booster_amount_3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "levels_table_boss_id_bosses_table_id_fk": {
+          "name": "levels_table_boss_id_bosses_table_id_fk",
+          "tableFrom": "levels_table",
+          "tableTo": "bosses_table",
+          "columnsFrom": [
+            "boss_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "levels_table_booster_id_1_boosters_table_id_fk": {
+          "name": "levels_table_booster_id_1_boosters_table_id_fk",
+          "tableFrom": "levels_table",
+          "tableTo": "boosters_table",
+          "columnsFrom": [
+            "booster_id_1"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "levels_table_booster_id_2_boosters_table_id_fk": {
+          "name": "levels_table_booster_id_2_boosters_table_id_fk",
+          "tableFrom": "levels_table",
+          "tableTo": "boosters_table",
+          "columnsFrom": [
+            "booster_id_2"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "levels_table_booster_id_3_boosters_table_id_fk": {
+          "name": "levels_table_booster_id_3_boosters_table_id_fk",
+          "tableFrom": "levels_table",
+          "tableTo": "boosters_table",
+          "columnsFrom": [
+            "booster_id_3"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "levels_table_level_unique": {
+          "name": "levels_table_level_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "level"
+          ]
+        }
+      }
+    },
+    "public.players_achievements_table": {
+      "name": "players_achievements_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achievement_id": {
+          "name": "achievement_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "players_achievements_table_player_id_players_table_id_fk": {
+          "name": "players_achievements_table_player_id_players_table_id_fk",
+          "tableFrom": "players_achievements_table",
+          "tableTo": "players_table",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "players_achievements_table_achievement_id_achievements_table_id_fk": {
+          "name": "players_achievements_table_achievement_id_achievements_table_id_fk",
+          "tableFrom": "players_achievements_table",
+          "tableTo": "achievements_table",
+          "columnsFrom": [
+            "achievement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.players_boosters_table": {
+      "name": "players_boosters_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "booster_id": {
+          "name": "booster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "player_booster_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "players_boosters_table_player_id_players_table_id_fk": {
+          "name": "players_boosters_table_player_id_players_table_id_fk",
+          "tableFrom": "players_boosters_table",
+          "tableTo": "players_table",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "players_boosters_table_booster_id_boosters_table_id_fk": {
+          "name": "players_boosters_table_booster_id_boosters_table_id_fk",
+          "tableFrom": "players_boosters_table",
+          "tableTo": "boosters_table",
+          "columnsFrom": [
+            "booster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.players_characters_table": {
+      "name": "players_characters_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "players_characters_table_player_id_players_table_id_fk": {
+          "name": "players_characters_table_player_id_players_table_id_fk",
+          "tableFrom": "players_characters_table",
+          "tableTo": "players_table",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "players_characters_table_character_id_characters_table_id_fk": {
+          "name": "players_characters_table_character_id_characters_table_id_fk",
+          "tableFrom": "players_characters_table",
+          "tableTo": "characters_table",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.players_table": {
+      "name": "players_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "firebase_id": {
+          "name": "firebase_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty_id": {
+          "name": "difficulty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_character_id": {
+          "name": "selected_character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_year": {
+          "name": "birth_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "airflow": {
+          "name": "airflow",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_played_at": {
+          "name": "last_played_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "players_table_difficulty_id_difficulties_table_id_fk": {
+          "name": "players_table_difficulty_id_difficulties_table_id_fk",
+          "tableFrom": "players_table",
+          "tableTo": "difficulties_table",
+          "columnsFrom": [
+            "difficulty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "players_table_selected_character_id_characters_table_id_fk": {
+          "name": "players_table_selected_character_id_characters_table_id_fk",
+          "tableFrom": "players_table",
+          "tableTo": "characters_table",
+          "columnsFrom": [
+            "selected_character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "players_table_firebase_id_unique": {
+          "name": "players_table_firebase_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "firebase_id"
+          ]
+        },
+        "players_table_phone_number_unique": {
+          "name": "players_table_phone_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone_number"
+          ]
+        }
+      }
+    },
+    "public.vas_table": {
+      "name": "vas_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vas_score": {
+          "name": "vas_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vas_table_player_id_players_table_id_fk": {
+          "name": "vas_table_player_id_players_table_id_fk",
+          "tableFrom": "vas_table",
+          "tableTo": "players_table",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.booster_action": {
+      "name": "booster_action",
+      "schema": "public",
+      "values": [
+        "USE",
+        "GAIN"
+      ]
+    },
+    "public.booster_type": {
+      "name": "booster_type",
+      "schema": "public",
+      "values": [
+        "NORMAL",
+        "RARE"
+      ]
+    },
+    "public.booster_unique": {
+      "name": "booster_unique",
+      "schema": "public",
+      "values": [
+        "UNIQUE",
+        "NONUNIQUE"
+      ]
+    },
+    "public.game_session_status": {
+      "name": "game_session_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "CANCEL",
+        "END"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "M",
+        "F"
+      ]
+    },
+    "public.player_booster_status": {
+      "name": "player_booster_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "USED"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -43,6 +43,20 @@
       "when": 1722326453263,
       "tag": "0005_wooden_diamondback",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1724480063464,
+      "tag": "0006_exotic_shooting_star",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1724493612148,
+      "tag": "0007_optimal_ink",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
- add player reward response when calling finish-game
- add totalScore to players_table
- add player reward seed and change seed sequences

Remark: ที่ changes มันเยอะๆน่าจะมาจาก prettier กับ ESLint น่าจะ review ยากหน่อย ขอโทษครับ🙏